### PR TITLE
Update Battle2json.cs - fix reading from wrong JToken

### DIFF
--- a/WinApp/Code/Battle2json.cs
+++ b/WinApp/Code/Battle2json.cs
@@ -747,7 +747,7 @@ namespace WinApp.Code
                     else
                     {
                         Log.AddToLogBuffer(" > > Battle file returned result: '" + result + "', could not process JSON file: " + file);
-                        var message = token_common.SelectToken("message"); // get message
+                        var message = token_parser?.SelectToken("message"); // get message
                         if (message != null)
                             Log.AddToLogBuffer(" > > > Message: " + message.ToString());
                         Log.AddToLogBuffer(" > > Faulty battle file schedule for delete");


### PR DESCRIPTION
Fix error message being read from the wrong JToken when the json file has error.