### PR TITLE
Increase application version number. Update tank and map images in Admin.db

### DIFF
--- a/InstallerWix3/WotNumbersLicense.rtf
+++ b/InstallerWix3/WotNumbersLicense.rtf
@@ -1,7 +1,7 @@
 {\rtf1\ansi\deff0\nouicompat{\fonttbl{\f0\fnil\fcharset0 Calibri;}}
 {\colortbl ;\red0\green0\blue255;}
 {\*\generator Riched20 10.0.19041}\viewkind4\uc1 
-\pard\sa200\sl276\slmult1\f0\fs22\lang20 Thank you for installing Wot Numbers version 1.0.1\par
+\pard\sa200\sl276\slmult1\f0\fs22\lang20 Thank you for installing Wot Numbers version 1.0.2\par
 This version is simplified compared to previous versions. The online statisctics and forum pages has been discontinued, so no data is uploaded to web. This makes the application a bit faster though.\par
 The web site is also simplified, but you can still find it here:\par
 {{\field{\*\fldinst{HYPERLINK https://wotnumbers.com }}{\fldrslt{https://wotnumbers.com\ul0\cf0}}}}\f0\fs22\par

--- a/WinApp/Code/DbVersion.cs
+++ b/WinApp/Code/DbVersion.cs
@@ -45,6 +45,7 @@ namespace WinApp.Code
 					mssql =
 						"UPDATE columnSelection SET colName = 'CAST(battle.minBattleTier AS FLOAT)', colDataType = 'Float' WHERE id = 547;";
 					sqlite = mssql;
+					CopyAdminDB = true;
 					break;
 				case 541:
 					mssql =
@@ -64,7 +65,7 @@ namespace WinApp.Code
 						// Add column for wargamigAccountId
 						"ALTER TABLE player ADD accountId int NOT NULL DEFAULT(0);" +
 						// adding new map "outpost"
-						"INSERT INTO map (id, name, arena_id) VALUES (102, 'Outpost', '128_last_frontier_v'); ";
+						"INSERT INTO map (id, name, arena_id) VALUES (206, 'Outpost', '128_last_frontier_v'); ";
 					sqlite = mssql;
 					break;
 				case 538:

--- a/WinApp/Properties/AssemblyInfo.cs
+++ b/WinApp/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // - Second number = minor versjon
 // - Third number = not used
 // - Forth number = buid number (automaically)
-[assembly: AssemblyVersion("1.0.1.*")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
+[assembly: AssemblyVersion("1.0.2.*")]
+[assembly: AssemblyFileVersion("1.0.2.0")]


### PR DESCRIPTION
- Fix outpost id number (id is not created by WoTNumbers, it comes from battle json
- Update version number on installer and application
- Update app to force copy admin.db
- Update admin.db